### PR TITLE
feat(template): display dependency updates as table when possible

### DIFF
--- a/src/foxy_changelog/templates/compact.jinja2
+++ b/src/foxy_changelog/templates/compact.jinja2
@@ -15,7 +15,10 @@
 {{ macros.section('Docs 📚', release.docs) -}}
 {{ macros.section('Tools 🧰', release.tools) -}}
 {{ macros.section('Continuous integration 🐹', release.ci) -}}
+{%- if not release.deps_table -%}
 {{ macros.section('Dependency updates 📦', release.deps) -}}
+{%- endif -%}
+{{ macros.section_table('Dependency updates 📦', release.deps_table) -}}
 {{ macros.section('Others 🔨', release.builds+release.chore+release.reverts+release.style_changes+release.version) -}}
 
 {% if release.diff_url %}

--- a/src/foxy_changelog/templates/macros.jinja2
+++ b/src/foxy_changelog/templates/macros.jinja2
@@ -7,3 +7,16 @@
 {% endfor -%}
 {%- endif -%}
 {%- endmacro -%}
+
+
+{%- macro section_table(title, dependency_updates) -%}
+{%- if dependency_updates %}
+### {{ title }}
+
+| Dependency  | Previous version  | New version   |
+|:------------|:------------------|:--------------|
+{% for dependency_update in dependency_updates -%}
+|{{ dependency_update.name }}|{{ dependency_update.previous_version }}|{{ dependency_update.next_version }}|
+{% endfor -%}
+{%- endif -%}
+{%- endmacro -%}


### PR DESCRIPTION
Changes:

- Display dependency updates as table when possible. It is possible when the commit message is supported

Resolves #11 
