### PR TITLE
fix(changelog): improve parsing to consider scope containing - or .

### DIFF
--- a/src/foxy_changelog/repository.py
+++ b/src/foxy_changelog/repository.py
@@ -231,7 +231,7 @@ class GitRepository(RepositoryInterface):  # pylint: disable=too-few-public-meth
     def _parse_conventional_commit(message: str) -> tuple[str, str, str, str, str]:
         type_ = scope = description = body_footer = body = footer = ""
         # TODO this is less restrictive version of re. I have somewhere more restrictive one, maybe as option?
-        match = re.match(r"^(\w+)(\(\w+\))?!?: (.*)(\n\n[\w\W]*)?$", message.strip())
+        match = re.match(r"^(\w+)(\([\w\-.]+\))?!?: (.*)(\n\n[\w\W]*)?$", message.strip())
         if match:
             type_, scope, description, body_footer = match.groups(default="")
         else:


### PR DESCRIPTION
Changes:

- Old regex was not parsing scope which contains `-` or `.`. It is now fixed.

Resolves #24 
