### PR TITLE
feat(changelog): add a new template to render only the last release

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ Options:
 -r, --remote TEXT          Specify git remote to use for links
 -v, --latest-version TEXT  use specified version as latest release
 -u, --unreleased           Include section for unreleased changes
---template TEXT            specify template to use [compact] or a path to a
-                           custom template, default: compact
+--template TEXT            specify template to use [compact, lastrelease] or a path
+                           to a custom template, default: compact
 
 --diff-url TEXT            override url for compares, use {current} and
                            {previous} for tags

--- a/src/foxy_changelog/__main__.py
+++ b/src/foxy_changelog/__main__.py
@@ -36,7 +36,7 @@ def validate_template(ctx: Any, param: Any, value: str | None) -> str | None:  #
 
 def generate_changelog(
     repository: RepositoryInterface, presenter: PresenterInterface, *args: Any, **kwargs: Any
-) -> Any:
+) -> str:
     """Use-case function coordinates repository and interface"""
     changelog = repository.generate_changelog(*args, **kwargs)
     return presenter.present(changelog)
@@ -87,7 +87,7 @@ def generate_changelog(
     callback=validate_template,
     type=str,
     default=None,
-    help="specify template to use [compact] or a path to a custom template, default: compact ",
+    help="specify template to use [compact, lastrelease] or a path to a custom template, default: compact",
 )
 @click.option(
     "--diff-url", type=str, default=None, help="override url for compares, use {current} and {previous} for tags"

--- a/src/foxy_changelog/domain_model.py
+++ b/src/foxy_changelog/domain_model.py
@@ -322,5 +322,5 @@ class RepositoryInterface(ABC):  # pylint: disable=too-few-public-methods
 
 class PresenterInterface(ABC):  # pylint: disable=too-few-public-methods
     @abstractmethod
-    def present(self, changelog: Changelog) -> Any:
+    def present(self, changelog: Changelog) -> str:
         raise NotImplementedError

--- a/src/foxy_changelog/presenter.py
+++ b/src/foxy_changelog/presenter.py
@@ -12,7 +12,7 @@ from foxy_changelog.domain_model import PresenterInterface
 
 default_template_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "templates")
 
-default_template = {"compact": "compact.jinja2"}
+default_template = {"compact": "compact.jinja2", "lastrelease": "lastrelease.jinja2"}
 
 
 class MarkdownPresenter(PresenterInterface):  # pylint: disable=too-few-public-methods
@@ -25,7 +25,7 @@ class MarkdownPresenter(PresenterInterface):  # pylint: disable=too-few-public-m
         else:
             template_dir, template_name = os.path.split(template)
 
-        env = Environment(loader=FileSystemLoader(template_dir))
+        env = Environment(loader=FileSystemLoader(template_dir), autoescape=True)
 
         self.template = env.get_template(template_name)
 

--- a/src/foxy_changelog/templates/lastrelease.jinja2
+++ b/src/foxy_changelog/templates/lastrelease.jinja2
@@ -1,0 +1,22 @@
+{% import 'macros.jinja2' as macros -%}
+
+{%- set release = changelog.releases[0] -%}
+
+> `{{release.date}}`
+{{ macros.section('New features 🚀', release.features) -}}
+{{ macros.section('Fixes 🐞', release.fixes) -}}
+{{ macros.section('Performance improvements 🦅', release.performance_improvements) -}}
+{{ macros.section('Refactorings 🏭', release.refactorings) -}}
+{{ macros.section('Tests 🧪', release.tests) -}}
+{{ macros.section('Docs 📚', release.docs) -}}
+{{ macros.section('Tools 🧰', release.tools) -}}
+{{ macros.section('Continuous integration 🐹', release.ci) -}}
+{%- if not release.deps_table -%}
+{{ macros.section('Dependency updates 📦', release.deps) -}}
+{%- endif -%}
+{{ macros.section_table('Dependency updates 📦', release.deps_table) -}}
+{{ macros.section('Others 🔨', release.builds+release.chore+release.reverts+release.style_changes+release.version) -}}
+
+{% if release.diff_url %}
+Full set of changes: [`{{release.previous_tag}}...{{release.tag}}`]({{release.diff_url}})
+{% endif -%}


### PR DESCRIPTION
Changes:

- Add a new template to only render the last release. It is use full to automatically generate
release on github.
- Fix some typing
- Appy a recommandation from ruff to fix security issue

Resolves #27 
