### PR TITLE
refactor(project): add license header to every python files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Licence of codes from https://github.com/KeNaCo/auto-changelog
+
 The MIT License (MIT)
 
 Copyright (c) 2016 Michael Bryan - Ken Mijime

--- a/src/foxy_project/__init__.py
+++ b/src/foxy_project/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 

--- a/src/foxy_project/__main__.py
+++ b/src/foxy_project/__main__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 import logging

--- a/src/foxy_project/_config.py
+++ b/src/foxy_project/_config.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/foxy_project/domain_model.py
+++ b/src/foxy_project/domain_model.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 import logging

--- a/src/foxy_project/presenter.py
+++ b/src/foxy_project/presenter.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 import os

--- a/src/foxy_project/repository.py
+++ b/src/foxy_project/repository.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 import logging

--- a/src/foxy_project/setuptools_scm/__init__.py
+++ b/src/foxy_project/setuptools_scm/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2010-2024 Ronny Pfannschmidt <opensource@ronnypfannschmidt.de>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT

--- a/src/foxy_project/setuptools_scm/config/__init__.py
+++ b/src/foxy_project/setuptools_scm/config/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2010-2024 Ronny Pfannschmidt <opensource@ronnypfannschmidt.de>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT

--- a/src/foxy_project/setuptools_scm/config/pyproject_reading.py
+++ b/src/foxy_project/setuptools_scm/config/pyproject_reading.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2010-2024 Ronny Pfannschmidt <opensource@ronnypfannschmidt.de>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 import logging

--- a/src/foxy_project/setuptools_scm/config/setuptools.py
+++ b/src/foxy_project/setuptools_scm/config/setuptools.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2010-2024 Ronny Pfannschmidt <opensource@ronnypfannschmidt.de>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/foxy_project/setuptools_scm/config/toml.py
+++ b/src/foxy_project/setuptools_scm/config/toml.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2010-2024 Ronny Pfannschmidt <opensource@ronnypfannschmidt.de>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 import logging

--- a/src/foxy_project/setuptools_scm/version_scheme.py
+++ b/src/foxy_project/setuptools_scm/version_scheme.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2010-2024 Ronny Pfannschmidt <opensource@ronnypfannschmidt.de>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 

--- a/tests/test_domain_model.py
+++ b/tests/test_domain_model.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 from datetime import date

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 import logging

--- a/tests/test_presenter.py
+++ b/tests/test_presenter.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 from datetime import date

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2016-2024 Michael Bryan <michaelfbryan@gmail.com> - Ken Mijime <kenaco666@gmail.com>
+# SPDX-FileCopyrightText: 2024-present Fabien Hermitte
+#
+# SPDX-License-Identifier: MIT
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock


### PR DESCRIPTION
Changes:

- It is important their is a license header on every python files

Resolves #36 
