### PR TITLE
fix(project): replace old project name on build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,5 @@
 [build-system]
-requires = [
-    "hatchling",
-    "hatch-requirements-txt",
-    "hatch-vcs",
-    "foxy-changelog",
-]
+requires = ["hatchling", "hatch-requirements-txt", "hatch-vcs", "foxy-project"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Changes:

- Replace old name of project in the build dependencies to make the project build again

