### PR TITLE
ci(workflow): use hash instead of tag to specify version of actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,7 +19,7 @@ jobs:
       tag: ${{ steps.generate-release.outputs.tag }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -33,12 +33,12 @@ jobs:
     needs: release
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: "3.12"
       - name: Set up pip cache
@@ -56,7 +56,7 @@ jobs:
       - name: Install Hatch
         run: hatch build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: python-artifacts
           path: dist/*
@@ -69,11 +69,11 @@ jobs:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: Download Python artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           name: python-artifacts
           path: dist
       - name: Push Python artifacts to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.11
+        uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # v1.8.11
         with:
           skip-existing: true

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/actions/create-release/action.yml
+++ b/actions/create-release/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Install python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: "3.12"
     - name: Install foxy-project

--- a/actions/generate-changelog/action.yml
+++ b/actions/generate-changelog/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Install python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
       with:
         python-version: "3.12"
     - name: Install foxy-project


### PR DESCRIPTION
Changes:

- use hash instead of tag to specify version of actions to improve security
